### PR TITLE
Allow building using docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:14
+
+RUN apt-get -qq update && apt-get -qq install --no-install-recommends -y \
+    curl \
+    g++ \
+    gcc \
+    git \
+    jq \
+    libarchive-tools \
+    libsecret-1-dev \
+    libsqlcipher-dev \
+    libssl-dev \
+    make \
+    openssl \
+    pkg-config \
+    python \
+    tcl \
+    vim
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal
+
+WORKDIR /project

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ OUT_WIN64_PORTABLE_BETTER_NAME := $(PRODUCT_NAME)_win-portable_v$(VERSION)
 OUT_MACOS := $(DESKTOP_OUT)/$(PRODUCT_NAME)-$(VERSION)-universal.dmg
 OUT_MACOS_MAS := $(DESKTOP_OUT)/mas-universal/$(PRODUCT_NAME).app
 
+DOCKER_IMAGE := schildichat-desktop-dockerbuild
+
 RELEASE_DIR := release
 CURRENT_RELEASE_DIR := $(RELEASE_DIR)/$(VERSION)
 
@@ -59,6 +61,14 @@ icns: element-desktop/build/icon.icns element-desktop/build/dmg.icns
 
 regenerate-i18n: setup
 	./regenerate_i18n.sh
+
+docker-build:
+	docker build -t schildichat-desktop-dockerbuild .
+
+docker-pacman: docker-build
+	docker run --rm -ti \
+		-v ${PWD}:/project \
+		${DOCKER_IMAGE} make pacman
 
 web: export DIST_VERSION=$(WEB_OUT_DIST_VERSION)
 web: setup


### PR DESCRIPTION
At the time of writing, I blindly took the installation requirements from the README, and some dockerfile directives from `element-desktop/dockerbuild/Dockerfile` in order to construct this current `Dockerfile`. So far, I think it looks cleaner, though it definitely does not yet implement caching, and I only wrote a single new target `make docker-pacman` as a proof-of-concept.

But I'm definitely interested in doing this properly/implementing this further if there's any interest, and if this could help others build/develop on schildichat, and helping CI get going for the main devs.