### PR TITLE
Create the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Please report a bug to improve SchildiChat Web/Desktop.
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Description**:
+<!-- Please write a clear and concise description of the issue you experience. -->
+
+**Steps to reproduce the bug**:
+
+1.
+2.
+3.
+
+**Expected result**:
+<!-- Please write a clear and concise description of what you expected to happen. -->
+
+**Actual result**:
+<!-- Please write a clear and concise description of what actually happened instead. -->
+
+**Client**:
+- SchildiChat version: [e.g. 1.11.36-sc.3]
+- Olm version: [e.g. 3.2.14]
+- OS:
+- Browser:
+
+**Additional context**:
+<!-- Please provide context about the problem here, if any. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Questions & support
+      url: https://matrix.to/#/#web:schildi.chat
+      about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature-suggestion.md
@@ -1,0 +1,17 @@
+---
+name: Feature suggestion
+about: Please submit your idea to improve SchildiChat Web/Desktop.
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Description**:
+<!-- Please write a clear and concise description of your suggestion. -->
+
+**Describe alternatives you've considered**:
+<!-- Please describe alternative ways to achieve what you wanted to do, if any. -->
+
+**Additional context**:
+<!-- Please provide context about the problem here, if any. -->


### PR DESCRIPTION
This PR intends to add the issue templates on GitHub to improve UX on reporting a bug or suggesting a feature.

![1](https://github.com/SchildiChat/schildichat-desktop/assets/3362943/833a0d9a-1ed7-4894-9f6d-50e7cf866916)

Bug report:

![2](https://github.com/SchildiChat/schildichat-desktop/assets/3362943/95c9dfab-a6a6-453f-83b7-991b49ca0f23)

Feature suggestion:

![3](https://github.com/SchildiChat/schildichat-desktop/assets/3362943/b789cfb6-4475-4169-a120-dc9102e39620)
