### PR TITLE
Bring back Nix flake (WIP)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "desktop": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708941445,
-        "narHash": "sha256-2EmEbDQe4jSWflDJUoxmdMotQgNd+wzT3I7+19tFRRI=",
-        "owner": "SchildiChat",
-        "repo": "element-desktop",
-        "rev": "fb2931eb808d99995a4cd5ef168e8d4697f39e3f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "SchildiChat",
-        "repo": "element-desktop",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1699380656,
@@ -33,24 +17,23 @@
     },
     "root": {
       "inputs": {
-        "desktop": "desktop",
         "nixpkgs": "nixpkgs",
-        "web": "web"
+        "schildichat": "schildichat"
       }
     },
-    "web": {
+    "schildichat": {
       "flake": false,
       "locked": {
-        "lastModified": 1746198330,
-        "narHash": "sha256-VWv5AblkbYttP5solV75nqdHDSnRCbR+Hbi35e25XhQ=",
-        "owner": "element-hq",
-        "repo": "element-web",
-        "rev": "9ec54c534dc5b2511dc590371ca9c978fc3b897f",
+        "lastModified": 1758092383,
+        "narHash": "sha256-xwFJihAc2JsEm2OGE2RG6vmhSYqFTINdWbN6VJC3LKc=",
+        "owner": "SchildiChat",
+        "repo": "schildichat-desktop",
+        "rev": "4d4dcf1f7baf4cfaa1784940e479fd432d7e9af1",
         "type": "github"
       },
       "original": {
-        "owner": "element-hq",
-        "repo": "element-web",
+        "owner": "SchildiChat",
+        "repo": "schildichat-desktop",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "desktop": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708941445,
+        "narHash": "sha256-2EmEbDQe4jSWflDJUoxmdMotQgNd+wzT3I7+19tFRRI=",
+        "owner": "SchildiChat",
+        "repo": "element-desktop",
+        "rev": "fb2931eb808d99995a4cd5ef168e8d4697f39e3f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SchildiChat",
+        "repo": "element-desktop",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1699380656,
@@ -17,7 +33,25 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "desktop": "desktop",
+        "nixpkgs": "nixpkgs",
+        "web": "web"
+      }
+    },
+    "web": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1746198330,
+        "narHash": "sha256-VWv5AblkbYttP5solV75nqdHDSnRCbR+Hbi35e25XhQ=",
+        "owner": "element-hq",
+        "repo": "element-web",
+        "rev": "9ec54c534dc5b2511dc590371ca9c978fc3b897f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "element-hq",
+        "repo": "element-web",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,8 @@
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs;
 
-    desktop = {
-      url = github:SchildiChat/element-desktop;
-      flake = false;
-    };
-
-    web = {
-      url = github:SchildiChat/element-web;
+    schildichat = {
+      url = "git+https://github.com/SchildiChat/schildichat-desktop?submodules=1";
       flake = false;
     };
   };
@@ -19,7 +14,7 @@
     systems = [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
   in {
-    packages = forAllSystems(system: let pkgs = import nixpkgs {
+    packages = forAllSystems (system: let pkgs = import nixpkgs {
       inherit system;
     }; in {
       schildichat-desktop = pkgs.callPackage ./nix/desktop.nix { inherit inputs pkgs; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,44 +1,31 @@
 {
   description = "The SchildiChat Matrix client";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs;
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs;
 
-  outputs = { self, nixpkgs }: let
+    desktop = {
+      url = github:SchildiChat/element-desktop;
+      flake = false;
+    };
+
+    web = {
+      url = github:SchildiChat/element-web;
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, ... }@inputs: let
     systems = [ "x86_64-linux" "i686-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
-
-    overlay = import ./nix/overlay.nix;
-
-    # Memoize nixpkgs for different platforms for efficiency.
-    nixpkgsFor = forAllSystems (system:
-      import nixpkgs {
-        inherit system;
-        overlays = [ overlay ];
-      });
   in {
-    inherit overlay;
+    packages = forAllSystems(system: let pkgs = import nixpkgs {
+      inherit system;
+    }; in {
+      schildichat-desktop = pkgs.callPackage ./nix/desktop.nix { inherit inputs pkgs; };
+      schildichat-web = pkgs.callPackage ./nix/web.nix { inherit inputs pkgs; };
 
-    packages = builtins.mapAttrs (system: pkgs: {
-      inherit (pkgs)
-        schildichat-web
-        schildichat-desktop
-        schildichat-desktop-wayland
-      ;
-    }) nixpkgsFor;
-
-    defaultPackage = forAllSystems (system: self.packages.${system}.schildichat-desktop);
-
-    apps = forAllSystems(system: {
-      schildichat-desktop = {
-        type = "app";
-        program = "${self.packages.${system}.schildichat-desktop}/bin/schildichat-desktop";
-      };
-      schildichat-desktop-wayland = {
-        type = "app";
-        program = "${self.packages.${system}.schildichat-desktop-wayland}/bin/schildichat-desktop";
-      };
+      schildichat-desktop-wayland = self.packages.${system}.schildichat-desktop.override { useWayland = true; };
     });
-
-    defaultApp = forAllSystems (system: self.apps.${system}.schildichat-desktop);
   };
 }

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -1,0 +1,85 @@
+{ inputs, pkgs, useWayland ? false }:
+
+let
+  packageJSON = inputs.desktop + "/package.json";
+  yarnLock = inputs.desktop + "/yarn.lock";
+
+  schildichat-web = pkgs.callPackage ./web.nix { inherit inputs pkgs; };
+  package = builtins.fromJSON (builtins.readFile packageJSON);
+
+  pname = "schildichat-desktop";
+  version = package.version;
+
+  electron_exec = if pkgs.stdenv.isDarwin 
+    then "${pkgs.electron}/Applications/Electron.app/Contents/MacOS/Electron"
+    else "${pkgs.electron}/bin/electron";
+in pkgs.mkYarnPackage rec {
+  inherit (pkgs.element-desktop) seshat keytar;
+  inherit pname version packageJSON;
+
+  src = inputs.desktop;
+  nativeBuildInputs = with pkgs; [ makeWrapper ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+    pushd deps/schildichat-desktop/
+    npx tsc
+    yarn run i18n
+    node ./scripts/copy-res.js
+    popd
+
+    rm -rf node_modules/matrix-seshat node_modules/keytar
+    ln -s $keytar node_modules/keytar
+    ln -s $seshat node_modules/matrix-seshat
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # resources
+    mkdir -p "$out/share/element"
+    ln -s '${schildichat-web}' "$out/share/element/webapp"
+    cp -r './deps/schildichat-desktop' "$out/share/element/electron"
+    cp -r './deps/schildichat-desktop/res/img' "$out/share/element"
+    rm "$out/share/element/electron/node_modules"
+    cp -r './node_modules' "$out/share/element/electron"
+    cp $out/share/element/electron/lib/i18n/strings/en_EN.json $out/share/element/electron/lib/i18n/strings/en-us.json
+    ln -s $out/share/element/electron/lib/i18n/strings/en{-us,}.json
+
+    # icons
+    for icon in $out/share/element/electron/build/icons/*.png; do
+      mkdir -p "$out/share/icons/hicolor/$(basename $icon .png)/apps"
+      ln -s "$icon" "$out/share/icons/hicolor/$(basename $icon .png)/apps/element.png"
+    done
+
+    # desktop item
+    mkdir -p "$out/share"
+    ln -s "${builtins.elemAt desktopItems 0}/share/applications" "$out/share/applications"
+
+    # executable wrapper
+    makeWrapper '${electron_exec}' "$out/bin/${pname}" \
+      --add-flags "$out/share/element/electron${pkgs.lib.optionalString useWayland " --enable-features=UseOzonePlatform --ozone-platform=wayland"}"
+
+    runHook postInstall
+  '';
+
+  distPhase = "true";
+  desktopItems = [
+    (pkgs.makeDesktopItem {
+      name = "schildichat-desktop";
+      exec = "${pname} %u";
+      icon = "schildichat";
+      desktopName = "SchildiChat";
+      genericName = "Matrix Client";
+      categories = ["Network" "InstantMessaging" "Chat"];
+      extraConfig = {
+        StartupWMClass = "schildichat";
+        MimeType = "x-scheme-handler/element";
+      };
+    })
+  ];
+}

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -1,8 +1,8 @@
 { inputs, pkgs, useWayland ? false }:
 
 let
-  packageJSON = inputs.desktop + "/package.json";
-  yarnLock = inputs.desktop + "/yarn.lock";
+  packageJSON = "${inputs.schildichat}/element-desktop/package.json";
+  yarnLock = "${inputs.schildichat}/element-web/yarn.lock";
 
   schildichat-web = pkgs.callPackage ./web.nix { inherit inputs pkgs; };
   package = builtins.fromJSON (builtins.readFile packageJSON);
@@ -17,7 +17,7 @@ in pkgs.mkYarnPackage rec {
   inherit (pkgs.element-desktop) seshat keytar;
   inherit pname version packageJSON;
 
-  src = inputs.desktop;
+  src = "${inputs.schildichat}/element-desktop";
   nativeBuildInputs = with pkgs; [ makeWrapper ];
 
   buildPhase = ''

--- a/nix/web.nix
+++ b/nix/web.nix
@@ -1,0 +1,63 @@
+{ inputs, pkgs }:
+
+let
+  packageJSON = inputs.web + "/package.json";
+  yarnLock = inputs.web + "/yarn.lock";
+
+  package = builtins.fromJSON (builtins.readFile packageJSON);
+
+  pname = "schildichat-web";
+  version = package.version;
+
+  modules = pkgs.mkYarnModules {
+    name = "${pname}-modules-${version}";
+    inherit pname version packageJSON yarnLock;
+  };
+in pkgs.stdenv.mkDerivation {
+  inherit pname version;
+
+  src = inputs.web;
+  buildInputs = with pkgs; [ nodejs ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+
+    # TODO: find a way to copy default configuration
+    # cp configs/sc/config.json element-web/
+    cp -r ${modules}/node_modules .
+
+    chmod u+rwX -R node_modules
+    rm -rf element-web
+    mkdir element-web
+    
+    cp -r ${inputs.web}/* element-web
+    ln -s $PWD/node_modules element-web/
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd element-web
+    node scripts/copy-res.js
+    node_modules/.bin/webpack --progress --mode production
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r element-web/webapp $out
+
+    runHook postInstall
+  '';
+
+  passthru = { inherit modules; };
+}

--- a/nix/web.nix
+++ b/nix/web.nix
@@ -1,8 +1,8 @@
 { inputs, pkgs }:
 
 let
-  packageJSON = inputs.web + "/package.json";
-  yarnLock = inputs.web + "/yarn.lock";
+  packageJSON = "${inputs.schildichat}/element-web/package.json";
+  yarnLock = "${inputs.schildichat}/element-web/yarn.lock";
 
   package = builtins.fromJSON (builtins.readFile packageJSON);
 
@@ -16,8 +16,8 @@ let
 in pkgs.stdenv.mkDerivation {
   inherit pname version;
 
-  src = inputs.web;
-  buildInputs = with pkgs; [ nodejs ];
+  src = "${inputs.schildichat}/element-web";
+  buildInputs = [ pkgs.nodejs ];
 
   postPatch = ''
     patchShebangs .
@@ -34,7 +34,7 @@ in pkgs.stdenv.mkDerivation {
     rm -rf element-web
     mkdir element-web
     
-    cp -r ${inputs.web}/* element-web
+    cp -r ${inputs.schildichat}/element-web/* element-web
     ln -s $PWD/node_modules element-web/
 
     runHook postConfigure


### PR DESCRIPTION
Closes #284 

# About  
This PR reintroduces a flake for NixOS. NixOS is a declarative operating system that enables persistent configuration across multiple machines.

> [!WARNING]  
> This PR is a work in progress. I’ve encountered some issues and currently don’t know how to resolve them. I’ll continue investigating.

# Changes  

## Removed built-in overlay support:
**Old syntax:**
```nix
# Old way
{ pkgs }:

{ environment.systemPackages = with pkgs; [ schildichat-desktop ]; }
```

**New syntax:**
```nix
# New way
{ inputs }:

{ environment.systemPackages = [ inputs.schildi.packages.${pkgs.system}.schildichat-desktop ] }
```

> [!TIP]  
> This change may be confusing at first. If you want to use overlays on top of Nixpkgs, you can do something like this (assuming this repository is imported into your `flake.nix` as `schildi`):  
`overlay.nix`:
```nix
inputs: final: prev: {
  schildichat-desktop = inputs.schildi.packages.${final.system}.schildichat-desktop;
}
```
Then reference it in `flake.nix` like this:
```nix
let
  sc = import ./overlay.nix inputs;
  pkgs = import nixpkgs {
    inherit system;
    overlays = [ sc ];
  };
```

## Removed the following shortcuts:  
Assuming this flake is bound to the variable `sc`:  
- `sc.defaultPackage`, `sc.defaultApp` — previously pointed to `sc.packages.${system}.schildichat-desktop`  
- `sc.apps` — removed because it’s redundant; packages already contain the required desktop entries  

## Changed the way the code is downloaded
Unfortunately, Nix does not support downloading Git repositories with submodules. As a result, when this repository is fetched as a flake, the `element-web` and `element-desktop` directories are empty even though they are critical build dependencies.

To work around this, I’ve added them as separate flake inputs and fetch each repository manually. While this may not be the most elegant and performance-first solution, it's the best approach I can think of for now.

# Issues  
After installing Yarn modules using `mkYarnModules`, the `postcss-scss` package is missing. Because of this, I can't build the app. Everything else appears to be working, although I can’t verify it since `schildichat-desktop` depends on `schildichat-web`.

There’s an alternative method called `fetchYarnDeps`, which allows you to install packages using `yarn install` along with an offline cache generated by this method. However, it requires you to provide a `sha256` hash. If any dependency updates, the hash must also be updated to reflect changes in `yarn.lock`, which could introduce inconsistencies and future issues.

> [!IMPORTANT]  
> If you have suggestions or requests for improvements, please leave a comment. For example, if you want certain aliases reinstated, I can easily add them back.